### PR TITLE
rafael/conversational_memory_buffer

### DIFF
--- a/backend/app/domain/schemas/base/model.py
+++ b/backend/app/domain/schemas/base/model.py
@@ -67,7 +67,7 @@ class ModelPredictionPerDatasetRequest(BaseModel):
 
 class ConversationWithBufferMemoryRequest(BaseModel):
     history: dict
-    model_name: str
+    model_name: dict
     provider: str
     prompt: str
     num_answers: int

--- a/backend/app/domain/services/base/context.py
+++ b/backend/app/domain/services/base/context.py
@@ -190,6 +190,7 @@ class ContextService:
         ]
         random.shuffle(all_models)
         selected_models = all_models[:number_of_samples]
+        print("Selected models were", selected_models)
         all_answers = []
         for id, model in enumerate(selected_models):
             model_name = list(model.keys())[0]

--- a/backend/app/domain/services/base/model.py
+++ b/backend/app/domain/services/base/model.py
@@ -28,7 +28,12 @@ from app.domain.services.base.rounduserexampleinfo import RoundUserExampleInfoSe
 from app.domain.services.base.score import ScoreService
 from app.domain.services.base.task import TaskService
 from app.domain.services.builder_and_evaluation.evaluation import EvaluationService
-from app.domain.services.utils.llm import OpenAIProvider, CohereProvider, AnthropicProvider, HuggingFaceProvider
+from app.domain.services.utils.llm import (
+    AnthropicProvider,
+    CohereProvider,
+    HuggingFaceProvider,
+    OpenAIProvider,
+)
 from app.infrastructure.repositories.dataset import DatasetRepository
 from app.infrastructure.repositories.model import ModelRepository
 from app.infrastructure.repositories.task import TaskRepository
@@ -54,7 +59,12 @@ class ModelService:
         self.s3 = self.session.client("s3")
         self.s3_bucket = os.getenv("AWS_S3_BUCKET")
         self.email_helper = EmailHelper()
-        self.providers = {'openai': OpenAIProvider(), 'cohere': CohereProvider(), 'huggingface': HuggingFaceProvider(), 'anthropic': AnthropicProvider()}
+        self.providers = {
+            "openai": OpenAIProvider(),
+            "cohere": CohereProvider(),
+            "huggingface": HuggingFaceProvider(),
+            "anthropic": AnthropicProvider(),
+        }
 
     def get_model_in_the_loop(self, task_id: str) -> str:
         model_in_the_loop_info = self.model_repository.get_model_in_the_loop(task_id)
@@ -398,9 +408,7 @@ class ModelService:
         for i in range(num_answers):
             response = {
                 "id": i,
-                "text": llm.conversational_generation(
-                    prompt, model_name, history
-                ),
+                "text": llm.conversational_generation(prompt, model_name, history),
                 "score": 0.5,
             }
             responses.append(response)

--- a/backend/app/domain/services/base/model.py
+++ b/backend/app/domain/services/base/model.py
@@ -28,7 +28,7 @@ from app.domain.services.base.rounduserexampleinfo import RoundUserExampleInfoSe
 from app.domain.services.base.score import ScoreService
 from app.domain.services.base.task import TaskService
 from app.domain.services.builder_and_evaluation.evaluation import EvaluationService
-from app.domain.services.utils.llm import OpenAIProvider
+from app.domain.services.utils.llm import OpenAIProvider, CohereProvider, AnthropicProvider, HuggingFaceProvider
 from app.infrastructure.repositories.dataset import DatasetRepository
 from app.infrastructure.repositories.model import ModelRepository
 from app.infrastructure.repositories.task import TaskRepository
@@ -54,7 +54,7 @@ class ModelService:
         self.s3 = self.session.client("s3")
         self.s3_bucket = os.getenv("AWS_S3_BUCKET")
         self.email_helper = EmailHelper()
-        self.openai_provider = OpenAIProvider()
+        self.providers = {'openai': OpenAIProvider(), 'cohere': CohereProvider(), 'huggingface': HuggingFaceProvider(), 'anthropic': AnthropicProvider()}
 
     def get_model_in_the_loop(self, task_id: str) -> str:
         model_in_the_loop_info = self.model_repository.get_model_in_the_loop(task_id)
@@ -387,29 +387,20 @@ class ModelService:
     def conversation_with_buffer_memory(
         self,
         history: dict,
-        model_name: str,
+        model_name: dict,
         provider: str,
         prompt: str,
         num_answers: int,
     ):
-        if provider == "openai":
-            llm = self.openai_provider.initialize(
-                model_name=model_name,
-            )
-        memory = ConversationBufferMemory()
-        for entry in history["user"]:
-            user_message = entry["text"]
-            memory.chat_memory.add_user_message(user_message)
-            if history["bot"]:
-                ai_message = history["bot"].pop(0)["text"]
-                memory.chat_memory.add_ai_message(ai_message)
+        print("Selected model was", model_name)
         responses = []
+        llm = self.providers[provider]
         for i in range(num_answers):
-            conversation = ConversationChain(llm=llm, memory=memory)
             response = {
                 "id": i,
-                "model_name": model_name,
-                "text": conversation.predict(input=prompt),
+                "text": llm.conversational_generation(
+                    prompt, model_name, history
+                ),
                 "score": 0.5,
             }
             responses.append(response)

--- a/backend/app/domain/services/utils/llm.py
+++ b/backend/app/domain/services/utils/llm.py
@@ -9,7 +9,6 @@ import cohere
 import openai
 import requests
 from anthropic import AI_PROMPT, HUMAN_PROMPT, Anthropic
-from langchain.llms import OpenAI
 
 from app.domain.services.base.task import TaskService
 
@@ -23,6 +22,10 @@ class LLMProvider(ABC):
     def generate_text(self, prompt: str, num_images: int) -> list:
         pass
 
+    @abstractmethod
+    def conversational_generation(self, prompt: str, model: dict, history: dict) -> str:
+        pass
+
     @property
     @abstractmethod
     def provider_name(self):
@@ -34,14 +37,29 @@ class OpenAIProvider(LLMProvider):
         self.api_key = os.getenv("OPENAI")
         openai.api_key = self.api_key
 
-    def generate_text(self, prompt: str, model: dict) -> str:
-        model = model[self.provider_name()]
-        messages = [{"role": "user", "content": prompt}]
+    def generate_text(self, prompt: str, model: dict, is_conversational: bool = False) -> str:
+        model = model[self.provider_name()]['model_name']
+        if is_conversational:
+            messages = prompt
+        else:
+            messages = [{"role": "user", "content": prompt}]
         response = openai.ChatCompletion.create(
             model=model,
             messages=messages,
         )
         return response["choices"][0]["message"]["content"]
+
+    def conversational_generation(self, prompt: str, model: dict, history: dict) -> str:
+        formatted_conversation = []
+        formatted_conversation.append({"role": "system", "content": "You are a helpful assistant."})
+        for user_entry, bot_entry in zip(history['user'], history['bot']):
+            user_text = user_entry['text']
+            bot_text = bot_entry['text']
+            formatted_conversation.append({"role": "user", "content": user_text})
+            formatted_conversation.append({"role": "assistant", "content": bot_text})
+
+        formatted_conversation.append({'role': 'user', 'content': prompt})
+        return self.generate_text(formatted_conversation, model, is_conversational=True)
 
     def provider_name(self):
         return "openai"
@@ -53,12 +71,16 @@ class HuggingFaceProvider(LLMProvider):
         pass
 
     def generate_text(self, prompt: str, model: dict) -> str:
+        return "I am HF"
         endpoint = model[self.provider_name()]["endpoint"]
         payload = {"inputs": prompt, "max_new_tokens": 100}
         response = requests.post(endpoint, json=payload, headers=self.headers)
         if response.status_code == 200:
             sample = response.json()[0]["generated_text"]
             return sample
+
+    def conversational_generation(self, prompt: str, model: dict) -> str:
+        return
 
     def provider_name(self):
         return "huggingface"
@@ -70,14 +92,35 @@ class AnthropicProvider(LLMProvider):
         self.anthropic = Anthropic(api_key=self.api_key)
         pass
 
-    def generate_text(self, prompt: str, model: dict) -> str:
+    def generate_text(self, prompt: str, model: dict, is_conversational: bool = False) -> str:
+        if is_conversational:
+            final_prompt = prompt
+        else:
+            final_prompt = f"{HUMAN_PROMPT}{prompt}{AI_PROMPT}"
+
         completion = self.anthropic.completions.create(
-            model=model[self.provider_name()],
+            model=model[self.provider_name()]['model_name'],
             max_tokens_to_sample=300,
-            prompt=f"{HUMAN_PROMPT}{prompt}{AI_PROMPT}",
+            prompt=final_prompt,
         )
 
         return completion.completion
+
+    def conversational_generation(self, prompt: str, model: dict, history: dict) -> str:
+        formatted_conversation = []
+        for user_entry, bot_entry in zip(history['user'], history['bot']):
+            user_text = user_entry['text']
+            bot_text = bot_entry['text']
+            formatted_conversation.append(f'Human: {user_text}')
+            formatted_conversation.append(f'Assistant: {bot_text}')
+
+        formatted_conversation.append(f'Human: {prompt}')
+        formatted_conversation.append('Assistant: ')
+
+        formatted_conversation = "\n\n".join(formatted_conversation)
+
+        conversation = self.generate_text(formatted_conversation, model, is_conversational=True)
+        return conversation.completion
 
     def provider_name(self):
         return "anthropic"
@@ -89,10 +132,26 @@ class CohereProvider(LLMProvider):
         self.cohere = cohere.Client(self.api_key)
         pass
 
-    def generate_text(self, prompt: str, model: dict) -> str:
-        response = self.cohere.generate(prompt=prompt, max_tokens=300, model=model)
-        print(response)
-        return response[0].text
+    def generate_text(self, prompt: str, model: dict, is_conversational: bool = False, chat_history = []) -> str:
+        model = model[self.provider_name()]['model_name']
+
+        if is_conversational:
+            response = self.cohere.chat(message=prompt, max_tokens=300, model=model, chat_history=chat_history)
+        else:
+            response = self.cohere.chat(message=prompt, max_tokens=300, model=model)
+
+        return response.text
+
+    def conversational_generation(self, prompt: str, model: dict, history: dict) -> str:
+        formatted_conversation = []
+        for user_entry, bot_entry in zip(history['user'], history['bot']):
+            user_text = user_entry['text']
+            bot_text = bot_entry['text']
+            formatted_conversation.append({"user_name": "User", "text": user_text})
+            formatted_conversation.append({"user_name": "Chatbot", "text": bot_text})
+
+
+        return self.generate_text(prompt, model, is_conversational=True, chat_history=formatted_conversation)
 
     def provider_name(self):
         return "cohere"

--- a/backend/app/domain/services/utils/llm.py
+++ b/backend/app/domain/services/utils/llm.py
@@ -37,8 +37,10 @@ class OpenAIProvider(LLMProvider):
         self.api_key = os.getenv("OPENAI")
         openai.api_key = self.api_key
 
-    def generate_text(self, prompt: str, model: dict, is_conversational: bool = False) -> str:
-        model = model[self.provider_name()]['model_name']
+    def generate_text(
+        self, prompt: str, model: dict, is_conversational: bool = False
+    ) -> str:
+        model = model[self.provider_name()]["model_name"]
         if is_conversational:
             messages = prompt
         else:
@@ -51,14 +53,16 @@ class OpenAIProvider(LLMProvider):
 
     def conversational_generation(self, prompt: str, model: dict, history: dict) -> str:
         formatted_conversation = []
-        formatted_conversation.append({"role": "system", "content": "You are a helpful assistant."})
-        for user_entry, bot_entry in zip(history['user'], history['bot']):
-            user_text = user_entry['text']
-            bot_text = bot_entry['text']
+        formatted_conversation.append(
+            {"role": "system", "content": "You are a helpful assistant."}
+        )
+        for user_entry, bot_entry in zip(history["user"], history["bot"]):
+            user_text = user_entry["text"]
+            bot_text = bot_entry["text"]
             formatted_conversation.append({"role": "user", "content": user_text})
             formatted_conversation.append({"role": "assistant", "content": bot_text})
 
-        formatted_conversation.append({'role': 'user', 'content': prompt})
+        formatted_conversation.append({"role": "user", "content": prompt})
         return self.generate_text(formatted_conversation, model, is_conversational=True)
 
     def provider_name(self):
@@ -92,14 +96,16 @@ class AnthropicProvider(LLMProvider):
         self.anthropic = Anthropic(api_key=self.api_key)
         pass
 
-    def generate_text(self, prompt: str, model: dict, is_conversational: bool = False) -> str:
+    def generate_text(
+        self, prompt: str, model: dict, is_conversational: bool = False
+    ) -> str:
         if is_conversational:
             final_prompt = prompt
         else:
             final_prompt = f"{HUMAN_PROMPT}{prompt}{AI_PROMPT}"
 
         completion = self.anthropic.completions.create(
-            model=model[self.provider_name()]['model_name'],
+            model=model[self.provider_name()]["model_name"],
             max_tokens_to_sample=300,
             prompt=final_prompt,
         )
@@ -108,18 +114,20 @@ class AnthropicProvider(LLMProvider):
 
     def conversational_generation(self, prompt: str, model: dict, history: dict) -> str:
         formatted_conversation = []
-        for user_entry, bot_entry in zip(history['user'], history['bot']):
-            user_text = user_entry['text']
-            bot_text = bot_entry['text']
-            formatted_conversation.append(f'Human: {user_text}')
-            formatted_conversation.append(f'Assistant: {bot_text}')
+        for user_entry, bot_entry in zip(history["user"], history["bot"]):
+            user_text = user_entry["text"]
+            bot_text = bot_entry["text"]
+            formatted_conversation.append(f"Human: {user_text}")
+            formatted_conversation.append(f"Assistant: {bot_text}")
 
-        formatted_conversation.append(f'Human: {prompt}')
-        formatted_conversation.append('Assistant: ')
+        formatted_conversation.append(f"Human: {prompt}")
+        formatted_conversation.append("Assistant: ")
 
         formatted_conversation = "\n\n".join(formatted_conversation)
 
-        conversation = self.generate_text(formatted_conversation, model, is_conversational=True)
+        conversation = self.generate_text(
+            formatted_conversation, model, is_conversational=True
+        )
         return conversation.completion
 
     def provider_name(self):
@@ -132,11 +140,15 @@ class CohereProvider(LLMProvider):
         self.cohere = cohere.Client(self.api_key)
         pass
 
-    def generate_text(self, prompt: str, model: dict, is_conversational: bool = False, chat_history = []) -> str:
-        model = model[self.provider_name()]['model_name']
+    def generate_text(
+        self, prompt: str, model: dict, is_conversational: bool = False, chat_history=[]
+    ) -> str:
+        model = model[self.provider_name()]["model_name"]
 
         if is_conversational:
-            response = self.cohere.chat(message=prompt, max_tokens=300, model=model, chat_history=chat_history)
+            response = self.cohere.chat(
+                message=prompt, max_tokens=300, model=model, chat_history=chat_history
+            )
         else:
             response = self.cohere.chat(message=prompt, max_tokens=300, model=model)
 
@@ -144,14 +156,15 @@ class CohereProvider(LLMProvider):
 
     def conversational_generation(self, prompt: str, model: dict, history: dict) -> str:
         formatted_conversation = []
-        for user_entry, bot_entry in zip(history['user'], history['bot']):
-            user_text = user_entry['text']
-            bot_text = bot_entry['text']
+        for user_entry, bot_entry in zip(history["user"], history["bot"]):
+            user_text = user_entry["text"]
+            bot_text = bot_entry["text"]
             formatted_conversation.append({"user_name": "User", "text": user_text})
             formatted_conversation.append({"user_name": "Chatbot", "text": bot_text})
 
-
-        return self.generate_text(prompt, model, is_conversational=True, chat_history=formatted_conversation)
+        return self.generate_text(
+            prompt, model, is_conversational=True, chat_history=formatted_conversation
+        )
 
     def provider_name(self):
         return "cohere"

--- a/frontends/web/src/new_front/components/CreateSamples/CreateSamples/AnnotationInterfaces/Contexts/Chatbot.tsx
+++ b/frontends/web/src/new_front/components/CreateSamples/CreateSamples/AnnotationInterfaces/Contexts/Chatbot.tsx
@@ -51,7 +51,7 @@ const Chatbot: FC<ChatbotProps> = ({
   const askQuestion = async () => {
     if (prompt !== "") {
       const generatedTexts = await post(
-        '/model/conversation_with_buffer_memory',
+        "/model/conversation_with_buffer_memory",
         {
           history: {
             ...chatHistory,
@@ -68,12 +68,11 @@ const Chatbot: FC<ChatbotProps> = ({
           prompt: prompt,
           num_answers: num_of_samples_chatbot,
         },
-      )
+      );
       if (response.ok) {
-        setNewResponses(generatedTexts)
-        setIsAskingQuestion(false)
-        setPrompt('')
-
+        setNewResponses(generatedTexts);
+        setIsAskingQuestion(false);
+        setPrompt("");
       }
       // const generatedTexts = [
       //   {

--- a/frontends/web/src/new_front/components/CreateSamples/CreateSamples/AnnotationInterfaces/Contexts/Chatbot.tsx
+++ b/frontends/web/src/new_front/components/CreateSamples/CreateSamples/AnnotationInterfaces/Contexts/Chatbot.tsx
@@ -50,47 +50,47 @@ const Chatbot: FC<ChatbotProps> = ({
 
   const askQuestion = async () => {
     if (prompt !== "") {
-      // const generatedTexts = await post(
-      //   '/model/conversation_with_buffer_memory',
-      //   {
-      //     history: {
-      //       ...chatHistory,
-      //       user: [
-      //         ...chatHistory.user,
-      //         {
-      //           id: chatHistory.bot[chatHistory.bot.length - 1].id + 1,
-      //           text: prompt,
-      //         },
-      //       ],
-      //     },
-      //     model_name: model_name,
-      //     provider: provider,
-      //     prompt: prompt,
-      //     num_answers: num_of_samples_chatbot,
-      //   },
-      // )
-      // if (response.ok) {
-      //   setNewResponses(generatedTexts)
-      //   setIsAskingQuestion(false)
-      //   setPrompt('')
+      const generatedTexts = await post(
+        '/model/conversation_with_buffer_memory',
+        {
+          history: {
+            ...chatHistory,
+            user: [
+              ...chatHistory.user,
+              {
+                id: chatHistory.bot[chatHistory.bot.length - 1].id + 1,
+                text: prompt,
+              },
+            ],
+          },
+          model_name: model_name,
+          provider: provider,
+          prompt: prompt,
+          num_answers: num_of_samples_chatbot,
+        },
+      )
+      if (response.ok) {
+        setNewResponses(generatedTexts)
+        setIsAskingQuestion(false)
+        setPrompt('')
 
-      // }
-      const generatedTexts = [
-        {
-          id: "1",
-          model_name: "GPT-3",
-          text: "As an AI language model, I do not have personal experiences or direct interactions with individuals who taught me specific information. My responses are generated based on a vast amount of pre-existing human knowledge that has been processed and organized by machine learning algorithms.",
-          score: 0.9,
-        },
-        {
-          id: "2",
-          model_name: "GPT-2",
-          text: "My training involved analyzing and learning from a wide range of text sources, such as books, articles, websites, and other textual materials available on the internet. The information I provide is a combination of general knowledge and patterns derived from the training data.",
-          score: 0.8,
-        },
-      ];
-      setNewResponses(generatedTexts);
-      setIsAskingQuestion(false);
+      }
+      // const generatedTexts = [
+      //   {
+      //     id: "1",
+      //     model_name: "GPT-3",
+      //     text: "As an AI language model, I do not have personal experiences or direct interactions with individuals who taught me specific information. My responses are generated based on a vast amount of pre-existing human knowledge that has been processed and organized by machine learning algorithms.",
+      //     score: 0.9,
+      //   },
+      //   {
+      //     id: "2",
+      //     model_name: "GPT-2",
+      //     text: "My training involved analyzing and learning from a wide range of text sources, such as books, articles, websites, and other textual materials available on the internet. The information I provide is a combination of general knowledge and patterns derived from the training data.",
+      //     score: 0.8,
+      //   },
+      // ];
+      // setNewResponses(generatedTexts);
+      // setIsAskingQuestion(false);
     } else {
       Swal.fire({
         icon: "error",


### PR DESCRIPTION
# Pull Request: PERDI Conversational Memory Buffer Implementation

## Summary

This PR creates the custom memory handler for all of the conversational providers we host except HuggingFace models.

## Changes Made

### 1. Created `conversational_generation` abstract method for the factory of LLM providers

- This abstract method allows the usage of chat histories to create a conversational pattern.

### 2. Reimplemented `conversation_with_buffer_memory` method to incorporate changes from 1.

- Removed langchain usage
- Implemented a loop. Eventually having a multiprocessing function might yield faster results, but I don't want to risk getting models overloaded.

## Your Contribution

Your contribution to this PR is greatly appreciated, and it plays a significant role in improving our platform's functionality and user experience.

## Reviewers

We kindly request a thorough review of the changes made in this PR to ensure its accuracy and effectiveness.

Thank you for your commitment to our platform's success!
