### PR TITLE
Fix - Rounds DropDown menu

### DIFF
--- a/frontends/web/src/containers/App.css
+++ b/frontends/web/src/containers/App.css
@@ -358,6 +358,27 @@ table.inspectModel thead td {
     margin-right: 5px;
 }
 
+.hide-scroll-bar {
+    --scrollbar-color-track: rgba(255, 255, 255, 0);
+    --scrollbar-color-thumb: rgb(255, 255, 255);
+}
+
+@supports (scrollbar-width: auto) {
+    .hide-scroll-bar {
+      scrollbar-color: var(--scrollbar-color-thumb) var(--scrollbar-color-track);
+    }
+}
+
+.hide-scroll-bar::-webkit-scrollbar {
+    width: 12px;
+    background-color: var(--scrollbar-color-thumb);
+}
+
+.hide-scroll-bar::-webkit-scrollbar-track {
+    background-color: var(--scrollbar-color-track);
+    width: 12px;
+}
+
 @media all and (min-width: 480px) {
     .text-nav-bar {
         display: none;

--- a/frontends/web/src/containers/App.css
+++ b/frontends/web/src/containers/App.css
@@ -365,7 +365,7 @@ table.inspectModel thead td {
 
 @supports (scrollbar-width: auto) {
     .hide-scroll-bar {
-      scrollbar-color: var(--scrollbar-color-thumb) var(--scrollbar-color-track);
+        scrollbar-color: var(--scrollbar-color-thumb) var(--scrollbar-color-track);
     }
 }
 

--- a/frontends/web/src/containers/App.js
+++ b/frontends/web/src/containers/App.js
@@ -128,7 +128,7 @@ class App extends React.Component {
           },
           (error) => {
             console.warn(error);
-            if (error.status === 401) {
+            if (error.status_code === 401) {
               this.api.logout();
             }
           }

--- a/frontends/web/src/new_front/components/Inputs/DropDownStats.tsx
+++ b/frontends/web/src/new_front/components/Inputs/DropDownStats.tsx
@@ -54,15 +54,16 @@ const DropDownStats = ({
       <div
         className={`${
           open ? "block" : "hidden"
-        } absolute right-0 mt-2 w-full rounded-md shadow-lg  ring-1 ring-black ring-opacity-5 `}
+        } absolute z-10 h-44 md:h-24 right-0 mt-2 w-full rounded-md shadow-lg  ring-1 ring-black ring-opacity-5 overflow-auto hide-scroll-bar bg-slate-50 md:bg-transparent`}
         role="menu"
         aria-orientation="vertical"
         aria-labelledby="menu-button"
+        tabIndex={-1}
       >
         {options?.map((option, key) => (
           <p
             key={key}
-            className="block w-full px-4 py-2 text-xl text-left text-white pointer"
+            className="block w-full px-4 py-2 text-xl text-left text-gray md:text-white pointer"
             role="menuitem"
             onClick={() => {
               onChange!(option);


### PR DESCRIPTION
## Context

- When the user clicks the chevron on the right side of the rounds counter a drop down will open, if the rounds count is higher than 3 the dropdown will go down below the image cover and the numbers won't be visible.

## Changes Made

1. Fix height for rounds dropdown and make the scrollbar transparent
- This should allow the user to see all the number and scroll.
<img width="224" alt="image" src="https://github.com/mlcommons/dynabench/assets/43832784/0e060b10-e9ea-45ef-8209-ab5cc48d7cfb">

2. DropDown background white and text black when mobile.
- This should allow the user to see all the number and scroll.
<img width="371" alt="image" src="https://github.com/mlcommons/dynabench/assets/43832784/ca9fae30-8b6e-4768-a895-cdaed0c62274">
