### PR TITLE
Fixture - Nibbler popup

### DIFF
--- a/frontends/web/src/new_front/components/CreateSamples/CreateSamples/AnnotationInterfaces/Contexts/SelectBetweenImagesGenerative.tsx
+++ b/frontends/web/src/new_front/components/CreateSamples/CreateSamples/AnnotationInterfaces/Contexts/SelectBetweenImagesGenerative.tsx
@@ -146,6 +146,7 @@ const SelectBetweenImagesGenerative: FC<
   };
 
   const generateImages = async () => {
+    setFirstMessageReceived(false);
     if (
       neccessaryFields.every(
         (item) =>
@@ -187,7 +188,7 @@ const SelectBetweenImagesGenerative: FC<
             setShowQueue(true);
             setPositionQueue(imagesHttp);
             await saveHistoricalData(prompt, setPromptHistory);
-            setTimeout(generateImages, 25000);
+            setTimeout(generateImages, 15000);
           }
         } else {
           Swal.fire({
@@ -236,6 +237,7 @@ const SelectBetweenImagesGenerative: FC<
   };
 
   const handlePromptHistory = async (prompt: string) => {
+    setFirstMessageReceived(false);
     setShowLoader(true);
     setArtifactsInput({
       ...artifactsInput,
@@ -283,7 +285,7 @@ const SelectBetweenImagesGenerative: FC<
           setShowQueue(true);
           setPositionQueue(imagesHttp);
           await saveHistoricalData(prompt, setPromptHistory);
-          setTimeout(generateImages, 25000);
+          setTimeout(generateImages, 15000);
         }
       } else {
         Swal.fire({


### PR DESCRIPTION
## Context

- The FE is taking more than enough to realize the images have been generated and when the popup it's been shown once if it is needed it doesn't appear anymore

## Changes Made

1. Decrease in 10 the seconds to send call to endpoint
- This would allow the user to see the result faster.

2.  Refresh the popup state when click on drop down or when click in generate images along with the enter key
- This would allow the user to see the popup every time it is needed 