### PR TITLE
Fixture - Model Leader Board

### DIFF
--- a/frontends/web/src/new_front/components/Tables/Leaderboard/TaskModelLeaderboardCard.jsx
+++ b/frontends/web/src/new_front/components/Tables/Leaderboard/TaskModelLeaderboardCard.jsx
@@ -124,11 +124,11 @@ const TaskModelLeaderboardCard = ({
       const datasetWeightsList = datasetWeights.map(
         (obj) =>
           obj.weight /
-          datasetWeights.reduce((sum, item) => sum + item.weight, 0),
+          datasetWeights.reduce((sum, item) => sum + item.weight, 0)
       );
       const metricWeightsList = metrics.map(
         (obj) =>
-          obj.weight / metrics.reduce((sum, item) => sum + item.weight, 0),
+          obj.weight / metrics.reduce((sum, item) => sum + item.weight, 0)
       );
       const scoreData = await post("/task/get_dynaboard_info_by_task_id/", {
         task_id: taskId,
@@ -319,9 +319,9 @@ const TaskModelLeaderboardCard = ({
                       history.push(
                         "/login?msg=" +
                           encodeURIComponent(
-                            "You need to login to create a leaderboard snapshot.",
+                            "You need to login to create a leaderboard snapshot."
                           ) +
-                          `&src=/tasks/${taskCode}`,
+                          `&src=/tasks/${taskCode}`
                       );
                     }
                   }}
@@ -348,9 +348,9 @@ const TaskModelLeaderboardCard = ({
                       history.push(
                         "/login?msg=" +
                           encodeURIComponent(
-                            "You need to login to fork a leaderboard.",
+                            "You need to login to fork a leaderboard."
                           ) +
-                          `&src=/tasks/${taskCode}`,
+                          `&src=/tasks/${taskCode}`
                       );
                     }
                   }}

--- a/frontends/web/src/new_front/components/Tables/Leaderboard/TaskModelLeaderboardCard.jsx
+++ b/frontends/web/src/new_front/components/Tables/Leaderboard/TaskModelLeaderboardCard.jsx
@@ -15,14 +15,17 @@ import {
   Modal,
   Popover,
 } from "react-bootstrap";
+import useFetch from "use-http";
+import { ScaleLoader } from "react-spinners";
+
 import UserContext from "containers/UserContext";
+
 import TaskModelLeaderboardTable from "new_front/components/Tables/Leaderboard/TaskModelLeaderboardTable";
 import { SortDirection } from "components/TaskLeaderboard/SortContainer";
 import {
   ForkModal,
   SnapshotModal,
 } from "components/TaskLeaderboard/ForkAndSnapshotModalWrapper";
-import useFetch from "use-http";
 
 const TaskModelLeaderboardCard = ({
   title,
@@ -121,11 +124,11 @@ const TaskModelLeaderboardCard = ({
       const datasetWeightsList = datasetWeights.map(
         (obj) =>
           obj.weight /
-          datasetWeights.reduce((sum, item) => sum + item.weight, 0)
+          datasetWeights.reduce((sum, item) => sum + item.weight, 0),
       );
       const metricWeightsList = metrics.map(
         (obj) =>
-          obj.weight / metrics.reduce((sum, item) => sum + item.weight, 0)
+          obj.weight / metrics.reduce((sum, item) => sum + item.weight, 0),
       );
       const scoreData = await post("/task/get_dynaboard_info_by_task_id/", {
         task_id: taskId,
@@ -316,9 +319,9 @@ const TaskModelLeaderboardCard = ({
                       history.push(
                         "/login?msg=" +
                           encodeURIComponent(
-                            "You need to login to create a leaderboard snapshot."
+                            "You need to login to create a leaderboard snapshot.",
                           ) +
-                          `&src=/tasks/${taskCode}`
+                          `&src=/tasks/${taskCode}`,
                       );
                     }
                   }}
@@ -345,9 +348,9 @@ const TaskModelLeaderboardCard = ({
                       history.push(
                         "/login?msg=" +
                           encodeURIComponent(
-                            "You need to login to fork a leaderboard."
+                            "You need to login to fork a leaderboard.",
                           ) +
-                          `&src=/tasks/${taskCode}`
+                          `&src=/tasks/${taskCode}`,
                       );
                     }
                   }}
@@ -417,24 +420,37 @@ const TaskModelLeaderboardCard = ({
           )}
         </div>
       </Card.Header>
-      <Card.Body className="p-0 leaderboard-container">
-        {!loading && data.length !== 0 && (
-          <TaskModelLeaderboardTable
-            data={data}
-            enableWeights={enableWeights}
-            metrics={metrics}
-            setMetricWeight={setMetricWeight}
-            enableDatasetWeights={enableDatasetWeights}
-            datasetWeights={datasetWeights}
-            setDatasetWeight={setDatasetWeight}
-            sort={sort}
-            toggleSort={toggleSort}
-            modelColumnTitle={modelColumnTitle}
-            showUserNames={task.show_username_leaderboard}
-            multiplyResultsByHundred={multiplyResultsByHundred}
-          />
-        )}
-      </Card.Body>
+      {loading ? (
+        <div className="grid justify-items-center">
+          <div>
+            <ScaleLoader
+              color="#ccebd4"
+              loading={loading}
+              size={50}
+              className="align-center"
+            />
+          </div>
+        </div>
+      ) : (
+        <Card.Body className="p-0 leaderboard-container">
+          {!loading && data.length !== 0 && (
+            <TaskModelLeaderboardTable
+              data={data}
+              enableWeights={enableWeights}
+              metrics={metrics}
+              setMetricWeight={setMetricWeight}
+              enableDatasetWeights={enableDatasetWeights}
+              datasetWeights={datasetWeights}
+              setDatasetWeight={setDatasetWeight}
+              sort={sort}
+              toggleSort={toggleSort}
+              modelColumnTitle={modelColumnTitle}
+              showUserNames={task.show_username_leaderboard}
+              multiplyResultsByHundred={multiplyResultsByHundred}
+            />
+          )}
+        </Card.Body>
+      )}
       <Card.Footer className="text-center">
         <Pagination className="float-right mb-0" size="sm">
           {disablePagination ? (

--- a/frontends/web/src/new_front/components/Tables/Leaderboard/TaskModelLeaderboardRow.tsx
+++ b/frontends/web/src/new_front/components/Tables/Leaderboard/TaskModelLeaderboardRow.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from "react";
+import React, { FC, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import ChevronExpandButton from "new_front/components/Buttons/ChevronExpandButton";
 
@@ -16,8 +16,18 @@ const TaskModelLeaderboardRow: FC<TaskModelLeaderboardRowProps> = ({
   multiplyResultsByHundred = false,
 }) => {
   const [expanded, setExpanded] = useState(false);
-  const [secondExpanded, setSecondExpanded] = useState(false);
+  const [secondExpanded, setSecondExpanded] = useState();
   const totalRows = expanded ? data.datasets.length + 1 : 1;
+
+  useEffect(() => {
+    setSecondExpanded(
+      data?.datasets?.reduce((acc: any, dataset: any) => {
+        acc[dataset.name] = false;
+        return acc;
+      }, {})
+    );
+  }, []);
+
   return (
     <>
       <tr key={data.model_id} onClick={() => setExpanded(!expanded)}>
@@ -80,7 +90,7 @@ const TaskModelLeaderboardRow: FC<TaskModelLeaderboardRowProps> = ({
 
 type TaskModelLeaderboardRowFirstLevelProps = {
   dataset: any;
-  secondExpanded: boolean;
+  secondExpanded: any;
   setSecondExpanded: any;
   multiplyResultsByHundred?: boolean;
 };
@@ -95,12 +105,20 @@ const TaskModelLeaderboardRowFirstLevel: FC<
 }) => {
   return (
     <>
-      <tr key={dataset.name} onClick={() => setSecondExpanded(!secondExpanded)}>
-        <td>
+      <tr
+        key={dataset.name}
+        onClick={() =>
+          setSecondExpanded((prevState: any) => ({
+            ...prevState,
+            [dataset.name]: !secondExpanded[dataset.name],
+          }))
+        }
+      >
+        <td className="pl-3">
           {dataset.name}
           {dataset.downstream_info && (
             <div style={{ float: "right" }}>
-              <ChevronExpandButton expanded={secondExpanded} />
+              <ChevronExpandButton expanded={secondExpanded[dataset.name]} />
             </div>
           )}
         </td>
@@ -128,7 +146,7 @@ const TaskModelLeaderboardRowFirstLevel: FC<
           </>
         )}
       </tr>
-      {secondExpanded &&
+      {secondExpanded[dataset.name] &&
         dataset.downstream_info &&
         dataset.downstream_info.map((downstream: any, i: number) => (
           <TaskModelLeaderboardRowSecondLevel
@@ -152,7 +170,7 @@ const TaskModelLeaderboardRowSecondLevel: FC<
   return (
     <>
       <tr key={downstream.name}>
-        <td>{downstream.sub_task}</td>
+        <td className="pl-5">{downstream.sub_task} </td>
 
         <td
           className="text-right"


### PR DESCRIPTION
## Context

- The dropdown levels of the leader board aren't very clear when unfolded and when the second level dropdown is open all the others at the same level are also opened.

<img width="1182" alt="image" src="https://github.com/user-attachments/assets/6f4e7d54-2539-453f-9e53-7cf9b2caf882">

## Changes Made

1. Implement different Padding to the levels of the dropdown.
- This would allow the users to differentiate the levels easily.

2. Prevent all the dropdowns of the second level to be open and closed when just one is.
- This would allow the user to have more control of what dropdown he/she/they want to left opened and closed.

<img width="1354" alt="image" src="https://github.com/user-attachments/assets/bd9230f4-dbd7-43af-8c8e-b3e7c36d6c13">
