### PR TITLE
Fix - Increment pool size

### DIFF
--- a/backend/app/infrastructure/connection.py
+++ b/backend/app/infrastructure/connection.py
@@ -31,7 +31,7 @@ CONNECTION_URI = (
 class Connection(metaclass=Singleton):
     def __init__(self) -> None:
         self.engine = create_engine(
-            CONNECTION_URI, echo=False, pool_pre_ping=True, pool_size=2, pool_recycle=60
+            CONNECTION_URI, echo=False, pool_pre_ping=True, pool_size=6, pool_recycle=60
         )
         self.metadata = MetaData()
 


### PR DESCRIPTION
## Context

- We've been experiencing some errors on the DB due to the Pool Size.

## Changes Made

1. Increase the pool size from 2 to 6.
- This would allow the connection with SQLAlchemy to have more sessions available for the queries.