### PR TITLE
Fixture - RTL text

### DIFF
--- a/frontends/web/src/index.css
+++ b/frontends/web/src/index.css
@@ -127,3 +127,12 @@ h2.active {
 .btn-link:hover {
     color: #344854;
 }
+
+.rtl {
+    direction: rtl;
+    text-align: right;
+}
+
+.ltr {
+    direction: ltr;
+}

--- a/frontends/web/src/new_front/components/CreateSamples/CreateSamples/AnnotationInterfaces/Contexts/SelectMultipleTextMultipleTags.tsx
+++ b/frontends/web/src/new_front/components/CreateSamples/CreateSamples/AnnotationInterfaces/Contexts/SelectMultipleTextMultipleTags.tsx
@@ -14,6 +14,30 @@ import MultiSelect from "new_front/components/Lists/MultiSelect";
 
 import generateLightRandomColor from "new_front/utils/helpers/functions/GenerateRandomLightColor";
 
+const RTLtexts = [
+  "ara",
+  "ary",
+  "arz",
+  "ars",
+  "arb",
+  "aeb",
+  "aii",
+  "aze",
+  "azj",
+  "azb",
+  "div",
+  "heb",
+  "hbo",
+  "ckb",
+  "kur",
+  "kmr",
+  "sdh",
+  "nqo",
+  "fas",
+  "syc",
+  "urd",
+];
+
 type MultipleTagsTypes = {
   preselectedTag?: string;
 };
@@ -62,6 +86,7 @@ const SelectMultipleTextMultipleTags: FC<
   const [contextId, setContextId] = useState<number | null>(null);
   const [loading2, setLoading2] = useState<boolean>(false);
   const [extraLabel, setExtraLabel] = useState<any>({});
+  const [rtl, setRTL] = useState<boolean>(false);
 
   const submitButton: HTMLElement | null = document.getElementById("submit");
 
@@ -107,6 +132,7 @@ const SelectMultipleTextMultipleTags: FC<
     submitButton && (submitButton.hidden = false);
     setLoading2(true);
     setSelectionInfo([]);
+    setRTL(RTLtexts.includes(value as string));
     fetch(
       `${process.env.REACT_APP_API_HOST_2}/context/get_random_context_from_key_value`,
       {
@@ -306,7 +332,7 @@ const SelectMultipleTextMultipleTags: FC<
                 />
               </div>
             </div>
-            <div>
+            <div dir="auto" className={`unicode-text ${rtl ? "rtl" : "ltf"}`}>
               <TextAnnotator
                 style={{ whiteSpace: "pre-line" }}
                 content={text}


### PR DESCRIPTION
## Context

- Texts that are written from Right to Left (Arabic, Hebrew, Persian, Urdu, etc) weren't rendered as they are supposed to be.

## Changes Made

1. Adjust text to the right and use dir attribute for div tag along with the proper direction CSS attribute.
- This would allow the user proficient in languages RTL to see it how it is supposed to.

<img width="1282" alt="image" src="https://github.com/user-attachments/assets/9b17ea82-580e-42cc-b709-0212f7504440">

There are some little adjustment to be made like some punctuation marks not being render well sometimes.
