### PR TITLE
Feature - add Source URL when needed

### DIFF
--- a/api/controllers/models.py
+++ b/api/controllers/models.py
@@ -215,6 +215,10 @@ def do_upload_via_train_files(credentials, tid, model_name):
     }
 
     endpoint_name = f"ts{int(time.time())}-{model_name}"
+    metadata = task_config.get("metadata", {})
+    proof = metadata.get("upload_proof", False)
+    source_url = bottle.request.forms.get("source_url", None)
+
     model = m.create(
         task_id=tid,
         user_id=user_id,
@@ -226,6 +230,7 @@ def do_upload_via_train_files(credentials, tid, model_name):
         endpoint_name=endpoint_name,
         deployment_status=DeploymentStatusEnum.predictions_upload,
         secret=secrets.token_hex(),
+        source_url=source_url if proof else None,
     )
     for dataset in datasets:
         if (

--- a/frontends/web/src/common/ApiService.js
+++ b/frontends/web/src/common/ApiService.js
@@ -727,11 +727,14 @@ export default class ApiService {
     });
   }
 
-  uploadTrainFiles(tid, modelName, files) {
+  uploadTrainFiles(tid, modelName, files, source_url = null) {
     const token = this.getToken();
     const formData = new FormData();
     for (const [name, file] of Object.entries(files)) {
       formData.append(name, file);
+    }
+    if (source_url) {
+      formData.append("source_url", source_url);
     }
     return this.fetch(
       `${this.domain}/models/upload_train_files/${tid}/${modelName}`,


### PR DESCRIPTION
## Context

- DCIC Challenge owner asked us to add an input for participant to add the source URL of their code.

## Changes Made

1. Include the input text on the front end.
- This would allow the users to see the input file and use it.

<img width="1119" alt="image" src="https://github.com/user-attachments/assets/96ccdf63-ef5f-4309-a81f-2376771e0d78" />


2. Include the source URL on the API backend.
- This would allow us to create the model with this parameter