### PR TITLE
Fixture - Overview First for Text Language Identification task

### DIFF
--- a/frontends/web/src/new_front/pages/Task/TaskPage.tsx
+++ b/frontends/web/src/new_front/pages/Task/TaskPage.tsx
@@ -128,7 +128,7 @@ const TaskPage = () => {
                     {(task.show_user_leaderboard !== 0 ||
                       task.show_leaderboard !== 0) && (
                       <TabOption
-                        optionTab={task.id === 45 ? 2 : 1}
+                        optionTab={task.id in [45, 60] ? 2 : 1}
                         tabName="Leaderboard"
                         openTab={openTab}
                         setOpenTab={setOpenTab}
@@ -136,7 +136,7 @@ const TaskPage = () => {
                     )}
                     {Object.entries(taskInstructions).length !== 0 && (
                       <TabOption
-                        optionTab={task.id === 45 ? 1 : 2}
+                        optionTab={task.id in [45, 60] ? 1 : 2}
                         tabName="Overview"
                         openTab={openTab}
                         setOpenTab={setOpenTab}


### PR DESCRIPTION
## Context

- Text Language Identification owners want the overview to appear first instead of the leaderboard.

## Changes Made

1. Include task id into list.
-This would allow the overview to be shown first instead of the leaderboard

