### PR TITLE
Fixture - Overview First

### DIFF
--- a/frontends/web/src/new_front/pages/Task/TaskPage.tsx
+++ b/frontends/web/src/new_front/pages/Task/TaskPage.tsx
@@ -128,7 +128,7 @@ const TaskPage = () => {
                     {(task.show_user_leaderboard !== 0 ||
                       task.show_leaderboard !== 0) && (
                       <TabOption
-                        optionTab={task.id in [45, 60] ? 2 : 1}
+                        optionTab={[45, 60].includes(task.id) ? 2 : 1}
                         tabName="Leaderboard"
                         openTab={openTab}
                         setOpenTab={setOpenTab}
@@ -136,7 +136,7 @@ const TaskPage = () => {
                     )}
                     {Object.entries(taskInstructions).length !== 0 && (
                       <TabOption
-                        optionTab={task.id in [45, 60] ? 1 : 2}
+                        optionTab={[45, 60].includes(task.id) ? 1 : 2}
                         tabName="Overview"
                         openTab={openTab}
                         setOpenTab={setOpenTab}
@@ -174,7 +174,7 @@ const TaskPage = () => {
               <div className="flex-auto">
                 <div className="tab-content tab-space">
                   {/* Remove after Nibbler finish */}
-                  {task.id !== 45 ? (
+                  {![45, 60].includes(task.id) ? (
                     <div className={openTab === 1 ? "block  px-4" : "hidden"}>
                       {task.show_user_leaderboard !== 0 ||
                       task.show_leaderboard !== 0 ? (
@@ -225,7 +225,7 @@ const TaskPage = () => {
                   )}
 
                   {/* Remove after Nibbler finish */}
-                  {task.id !== 45 ? (
+                  {![45, 60].includes(task.id) ? (
                     <>
                       {Object.entries(taskInstructions).length !== 0 && (
                         <div

--- a/frontends/web/src/new_front/pages/Task/TaskPage.tsx
+++ b/frontends/web/src/new_front/pages/Task/TaskPage.tsx
@@ -128,7 +128,7 @@ const TaskPage = () => {
                     {(task.show_user_leaderboard !== 0 ||
                       task.show_leaderboard !== 0) && (
                       <TabOption
-                        optionTab={task.id === 45 ? 2 : 1}
+                        optionTab={task.id in [45, 60] ? 2 : 1}
                         tabName="Leaderboard"
                         openTab={openTab}
                         setOpenTab={setOpenTab}
@@ -136,7 +136,7 @@ const TaskPage = () => {
                     )}
                     {Object.entries(taskInstructions).length !== 0 && (
                       <TabOption
-                        optionTab={task.id === 45 ? 1 : 2}
+                        optionTab={task.id in [45, 60] ? 1 : 2}
                         tabName="Overview"
                         openTab={openTab}
                         setOpenTab={setOpenTab}


### PR DESCRIPTION
## Context

- Adjust some other list ids to render properly the overview first

## Changes Made

1. Include the ID in some other lists.
- This would allow the user to see the leader board as the second tab.