### PR TITLE
Feature - Yaml validator

### DIFF
--- a/frontends/web/src/components/TaskOwnerPageComponents/Advanced.js
+++ b/frontends/web/src/components/TaskOwnerPageComponents/Advanced.js
@@ -10,22 +10,48 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from "react";
+import React, { useState } from "react";
 import { Container, Row, Form, Col, Card, Button } from "react-bootstrap";
 import { Formik } from "formik";
 import useFetch from "use-http";
+import yaml from "js-yaml";
 
 const Advanced = (props) => {
   const { post, response } = useFetch();
+  const [error, setError] = useState();
 
   const saveYamlConfig = async (values) => {
-    await post("task/update_config_yaml", {
-      task_id: props.task.id,
-      config_yaml: values.config_yaml,
-    });
-    if (response.ok) {
-      window.location.reload();
+    const validation = validateYamlConfig(values.config_yaml);
+    if (validation.valid) {
+      await post("task/update_config_yaml", {
+        task_id: props.task.id,
+        config_yaml: values.config_yaml,
+      });
+      if (response.ok) {
+        window.location.reload();
+      }
+    } else {
+      console.error("Invalid YAML config", validation.error_message);
     }
+  };
+
+  const validateYamlConfig = (text) => {
+    const errors = {};
+    if (!text) {
+      errors.error_message = "Required";
+      errors.valid = false;
+    } else {
+      try {
+        yaml.load(text);
+        errors.error_message = "";
+        errors.valid = true;
+      } catch (e) {
+        errors.valid = false;
+        errors.error_message = e.message;
+      }
+    }
+    setError(errors);
+    return errors;
   };
 
   return (
@@ -53,7 +79,7 @@ const Advanced = (props) => {
                 dirty,
               }) => (
                 <>
-                  <form className="px-4" onSubmit={handleSubmit}>
+                  <form noValidate className="px-4" onSubmit={handleSubmit}>
                     <Container>
                       <Form.Group
                         as={Row}
@@ -86,7 +112,15 @@ const Advanced = (props) => {
                             onChange={handleChange}
                             spellCheck={false}
                             style={{ fontSize: 12, fontFamily: "Courier New" }}
+                            isInvalid={error && !error?.valid}
                           />
+                          <Form.Control.Feedback type="invalid">
+                            <pre
+                              style={{ color: "red", whiteSpace: "pre-wrap" }}
+                            >
+                              {error?.error_message}
+                            </pre>
+                          </Form.Control.Feedback>
                         </Col>
                         <Form.Text id="paramsHelpBlock" muted>
                           DynaTask configuration strings are YAML objects that


### PR DESCRIPTION
## Context

- Sometimes a bad yaml file would be save into the DB and that would break the challenge page.

## Changes Made

1. Include yaml validation function
- This would allow the yaml to be validated before being send to the DB.

2. Include form control feedback 
- This would allow users to see what is wrong with the yaml file for them to correct
<img width="1099" alt="image" src="https://github.com/user-attachments/assets/f0b2d08a-0b3a-4fe1-b60b-41a7776668a6" />
