### PR TITLE
Fixture - Add space between button and text

### DIFF
--- a/frontends/web/src/new_front/components/CreateSamples/CreateSamples/AnnotationInterfaces/Contexts/SelectMultipleTextMultipleTags.tsx
+++ b/frontends/web/src/new_front/components/CreateSamples/CreateSamples/AnnotationInterfaces/Contexts/SelectMultipleTextMultipleTags.tsx
@@ -348,7 +348,7 @@ const SelectMultipleTextMultipleTags: FC<
                   {instruction?.selection_note}
                 </div>
               )}
-              <div className="mx-auto mb-4 col-start-10">
+              <div className="mx-auto mb-4 pl-4 md:pl-0 col-start-10">
                 <Button
                   className="border-0 font-weight-bold light-gray-bg task-action-btn"
                   onClick={() => handleSelectAll()}


### PR DESCRIPTION
## Context

- In some screens there isn't space between the explanatory text and the button to select al the text area.
<img width="767" alt="image" src="https://github.com/user-attachments/assets/150fca9b-0276-42cd-a4a3-b0720bcfee9f" />

## Changes Made

1. Include padding to the left of the button.
- This would allow the user to properly see a space between the text and the button.
<img width="757" alt="image" src="https://github.com/user-attachments/assets/95d79e32-f8ad-4886-923e-7df333aa432b" />
