### PR TITLE
Fixture - Reinstate OK Button

### DIFF
--- a/frontends/web/src/new_front/components/CreateSamples/CreateSamples/AnnotationInterfaces/Contexts/SelectMultipleTextMultipleTags.tsx
+++ b/frontends/web/src/new_front/components/CreateSamples/CreateSamples/AnnotationInterfaces/Contexts/SelectMultipleTextMultipleTags.tsx
@@ -260,7 +260,6 @@ const SelectMultipleTextMultipleTags: FC<
   };
 
   const closeSwal = () => {
-    console.log("closeSwal");
     Swal.close();
   };
 


### PR DESCRIPTION
## Context

- Users want to skip faster the successful popup.

## Changes Made

1. Decrease the amount of time from 2 seconds to 1 second.
- This would allow the pop-up to disappear faster if there is no interaction from the user.

2. Reinstate the ok button.
- This will allow the user to close the popup with any key press.

3. Prevent the text and the dropdown to be translated by the browser.
- This will prevent the text to be tagged to be translated by the browser if the user clicks on that functionality.

