### PR TITLE
Fixture - Allow token right after the other

### DIFF
--- a/frontends/web/src/new_front/components/CreateSamples/CreateSamples/AnnotationInterfaces/Contexts/SelectMultipleTextMultipleTags.tsx
+++ b/frontends/web/src/new_front/components/CreateSamples/CreateSamples/AnnotationInterfaces/Contexts/SelectMultipleTextMultipleTags.tsx
@@ -293,8 +293,8 @@ const SelectMultipleTextMultipleTags: FC<
     }
     const already = selectionInfo.find(
       (val: any) =>
-        (val.start <= start && val.end >= start) ||
-        (val.start <= end && val.end >= start)
+        (val.start < start && val.end > start) ||
+        (val.start < end && val.end > start)
     );
     value[valueLength - 1].start = start;
     value[valueLength - 1].end = end;


### PR DESCRIPTION
## Context

- Users can't label different continuous text.

## Changes Made

1. Remove equality.
- This would allow the user to not leve a space between selections.