### PR TITLE
Fixture - Authorization

### DIFF
--- a/backend/app/api/endpoints/base/model.py
+++ b/backend/app/api/endpoints/base/model.py
@@ -206,11 +206,6 @@ def get_model_prediction_by_dataset(model: ModelPredictionPerDatasetRequest):
     )
 
 
-@router.get("/get_amount_of_models_by_task/{task_id}", response_model=int)
-def get_amount_of_models_by_task(task_id: int):
-    return ModelService().get_amount_of_models_by_task(task_id)
-
-
 @router.post("/upload_prediction_to_s3")
 def upload_prediction_to_s3(
     user_id: int, task_code: str, model_name: str, predictions: UploadFile = File(...)

--- a/backend/app/api/endpoints/base/modelpublic.py
+++ b/backend/app/api/endpoints/base/modelpublic.py
@@ -1,0 +1,14 @@
+# Copyright (c) MLCommons and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from fastapi import APIRouter
+
+from app.domain.services.base.model import ModelService
+
+
+router = APIRouter()
+
+
+@router.get("/get_amount_of_models_by_task/{task_id}", response_model=int)
+def get_amount_of_models_by_task(task_id: int):
+    return ModelService().get_amount_of_models_by_task(task_id)

--- a/backend/app/api/endpoints/base/user.py
+++ b/backend/app/api/endpoints/base/user.py
@@ -6,13 +6,14 @@ from fastapi import APIRouter
 
 from app.domain.auth.authentication import LoginService
 from app.domain.schemas.auth.auth import CreateUserRequest, LoginRequest
+from app.domain.schemas.base.user import UserInfoBadges
 from app.domain.services.base.user import UserService
 
 
 router = APIRouter()
 
 
-@router.get("/get_user_with_badges/{user_id}", response_model={})
+@router.get("/get_user_with_badges/{user_id}", response_model=UserInfoBadges)
 async def get_task_id_by_task_code(user_id: str):
     return UserService().get_user_with_badges(user_id)
 
@@ -30,8 +31,3 @@ async def authenticate(model: LoginRequest):
 @router.post("/create_user")
 async def create_user(model: CreateUserRequest):
     return LoginService().create_user(model.email, model.password, model.username)
-
-
-@router.get("/download_users_info", response_model={})
-async def download_users_info():
-    return UserService().download_users_info()

--- a/backend/app/api/middleware/authorization.py
+++ b/backend/app/api/middleware/authorization.py
@@ -1,0 +1,59 @@
+# Copyright (c) MLCommons and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+from typing import TypedDict
+
+from fastapi import Depends, Request
+from fastapi.security import OAuth2PasswordBearer
+from jose import jwt
+
+from app.domain.helpers.exceptions import credentials_exception
+from app.infrastructure.repositories.user import UserRepository
+
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/login")
+
+
+async def verify_token(token: str):
+    try:
+        decoded_token = jwt.decode(
+            token,
+            os.getenv("JWT_SECRET"),
+            algorithms=[os.getenv("AUTH_HASH_ALGORITHM")],
+        )
+        return decoded_token
+    except Exception as e:
+        print(f"Token verification failed: {e}")
+        credentials_exception()
+
+
+class AccessTokenPayload(TypedDict):
+    email: str
+
+
+def get_find_user_repository():
+    return UserRepository()
+
+
+async def validate_access_token(
+    request: Request,
+    token: str = Depends(oauth2_scheme),
+    repository=Depends(get_find_user_repository),
+) -> None:
+    # The OAuth2PasswordBearer already extracts and validates the Bearer token format
+    # So we don't need to manually extract it from headers
+    decoded: AccessTokenPayload = await verify_token(token)
+    # While we migrate the login into Backend we are using id
+    # That is what the API sends in the token.
+    # email = decoded.get("email", None)
+    id = decoded.get("id", None)
+    if not id:
+        raise credentials_exception()
+    user = repository.get_by_id(id)
+    # Once we have mirated the login into Backend we will use email.
+    # user = repository.get_by_email(email)
+    if user is None or not user:
+        raise credentials_exception()
+    request.state.user = user

--- a/backend/app/domain/schemas/base/user.py
+++ b/backend/app/domain/schemas/base/user.py
@@ -1,0 +1,29 @@
+# Copyright (c) MLCommons and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from datetime import datetime as Time
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class UserBadges(BaseModel):
+    id: int
+    name: str
+    awarded: Time
+    uid: int
+    metadata_json: Optional[str] = None
+
+
+class UserInfoBadges(BaseModel):
+    id: int
+    email: str
+    username: str
+    examples_created: Optional[int] = None
+    examples_verified: Optional[int] = None
+    examples_verified_correct: Optional[int] = None
+    examples_verified_correct_fooled: Optional[int] = None
+    examples_verified_incorrect_fooled: Optional[int] = None
+    examples_fooled: Optional[int] = None
+    badges: List[UserBadges] = []

--- a/backend/app/domain/services/base/user.py
+++ b/backend/app/domain/services/base/user.py
@@ -48,7 +48,7 @@ class UserService:
     def get_user_with_badges(self, user_id: int):
         user_info = self.user_repository.get_info_by_user_id(user_id).__dict__
         badges = self.user_repository.get_badges_by_user_id(user_id)
-        user_info["badges"] = [badge for badge in badges]
+        user_info["badges"] = badges
         return user_info
 
     def get_stats_by_user_id(self, user_id: int):

--- a/backend/app/infrastructure/repositories/user.py
+++ b/backend/app/infrastructure/repositories/user.py
@@ -102,7 +102,8 @@ class UserRepository(AbstractRepository):
             session.commit()
 
     def get_badges_by_user_id(self, user_id: int) -> dict:
-        return self.session.query(Badge).filter(Badge.uid == user_id).all()
+        badges = self.session.query(Badge).filter(Badge.uid == user_id).all()
+        return self.instance_converter.instance_to_dict(badges)
 
     def get_info_by_user_id(self, user_id: int) -> dict:
         return self.session.query(self.model).filter(self.model.id == user_id).first()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from dotenv import load_dotenv
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.endpoints import auth
@@ -17,6 +17,7 @@ from app.api.endpoints.base import (
     example,
     historical_data,
     model,
+    modelpublic,
     round,
     rounduserexample,
     score,
@@ -25,7 +26,7 @@ from app.api.endpoints.base import (
     user,
 )
 from app.api.endpoints.builder_and_evaluation import evaluation
-from app.infrastructure.connection import Connection
+from app.api.middleware.authorization import validate_access_token
 
 
 load_dotenv()
@@ -53,19 +54,43 @@ def read_root():
 
 
 app.include_router(auth.router, prefix="/auth", tags=["auth"])
-app.include_router(model.router, prefix="/model", tags=["model"])
+app.include_router(
+    model.router,
+    prefix="/model",
+    tags=["model"],
+    dependencies=[Depends(validate_access_token)],
+)
+app.include_router(modelpublic.router, prefix="/model_public", tags=["model_public"])
 app.include_router(task.router, prefix="/task", tags=["task"])
 app.include_router(context.router, prefix="/context", tags=["context"])
-app.include_router(example.router, prefix="/example", tags=["example"])
+app.include_router(
+    example.router,
+    prefix="/example",
+    tags=["example"],
+    dependencies=[Depends(validate_access_token)],
+)
 app.include_router(score.router, prefix="/score", tags=["score"])
-app.include_router(dataset.router, prefix="/dataset", tags=["dataset"])
+app.include_router(
+    dataset.router,
+    prefix="/dataset",
+    tags=["dataset"],
+    dependencies=[Depends(validate_access_token)],
+)
 app.include_router(
     rounduserexample.router, prefix="/rounduserexample", tags=["rounduserexample"]
 )
 app.include_router(
-    evaluation.router, prefix="/builder_evaluation/evaluation", tags=["evaluation"]
+    evaluation.router,
+    prefix="/builder_evaluation/evaluation",
+    tags=["evaluation"],
+    dependencies=[Depends(validate_access_token)],
 )
-app.include_router(user.router, prefix="/user", tags=["user"])
+app.include_router(
+    user.router,
+    prefix="/user",
+    tags=["user"],
+    dependencies=[Depends(validate_access_token)],
+)
 app.include_router(
     task_proposals.router, prefix="/task_proposals", tags=["task_proposals"]
 )

--- a/frontends/web/src/containers/App.js
+++ b/frontends/web/src/containers/App.js
@@ -98,7 +98,7 @@ class RouterMonitor extends React.Component {
       ) {
         this.props.history.push(
           "/login?msg=" +
-            encodeURIComponent("You need to be logged in to access this beta."),
+            encodeURIComponent("You need to be logged in to access this beta.")
         );
       }
     }
@@ -138,7 +138,7 @@ class App extends React.Component {
               <Redirect push to="/logout" />;
               //In Case Redirect doesn't work window.location.href = "/logout";
             }
-          },
+          }
         );
       });
     }
@@ -148,7 +148,7 @@ class App extends React.Component {
       },
       (error) => {
         console.warn(error);
-      },
+      }
     );
   }
   componentDidMount() {

--- a/frontends/web/src/containers/App.js
+++ b/frontends/web/src/containers/App.js
@@ -98,7 +98,7 @@ class RouterMonitor extends React.Component {
       ) {
         this.props.history.push(
           "/login?msg=" +
-            encodeURIComponent("You need to be logged in to access this beta.")
+            encodeURIComponent("You need to be logged in to access this beta."),
         );
       }
     }
@@ -138,7 +138,7 @@ class App extends React.Component {
               <Redirect push to="/logout" />;
               //In Case Redirect doesn't work window.location.href = "/logout";
             }
-          }
+          },
         );
       });
     }
@@ -148,7 +148,7 @@ class App extends React.Component {
       },
       (error) => {
         console.warn(error);
-      }
+      },
     );
   }
   componentDidMount() {
@@ -171,7 +171,15 @@ class App extends React.Component {
     });
     const showContentOnly = query.content_only === "true";
     return (
-      <FetchProvider url={BASE_URL_2}>
+      <FetchProvider
+        url={BASE_URL_2}
+        options={{
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${this.api.getToken()}`,
+          },
+        }}
+      >
         <OverlayInstructionsProvider>
           <ParallaxProvider>
             <UserContext.Provider

--- a/frontends/web/src/new_front/pages/Task/TaskPage.tsx
+++ b/frontends/web/src/new_front/pages/Task/TaskPage.tsx
@@ -47,7 +47,7 @@ const TaskPage = () => {
         await Promise.all([
           await get(`/task/get_task_with_round_info_by_task_id/${taskId}`),
           await get(`/score/get_maximun_principal_score_by_task/${taskId}`),
-          await get(`/model/get_amount_of_models_by_task/${taskId}`),
+          await get(`/model_public/get_amount_of_models_by_task/${taskId}`),
           await get(`/task/get_task_instructions/${taskId}`),
         ]);
       if (response.ok) {


### PR DESCRIPTION
## Context

- We need to move the authorization from API to Backend and use it on the FrontEnd also organize some schemas for some endpoints in order to not send everything just the necessary.

## Changes Made

1. Create an authorization "middleware" using dependencies on routers.
- This would makes us closer to have everything on the backendv2.0.

2. Send token to Backend v2.0 from the FrontEnd.
- This would allow us to proper use the new addition of the authorization layer.

3. Use Schemas for get_user_with_badges endpoint.
- This would prevent the backend to send unnecessary info to the FrontEnd.

4. In order for us to use Schemas on the previous endpoint mentioned the return should be a dict instead of a ORMtype object.
- This would prevent erros when using the Schemas.
<img width="704" height="759" alt="image" src="https://github.com/user-attachments/assets/fe92fe0d-b43b-4057-92a3-067122b53ede" />

5. Separate models endpoints that can be access without token from the ones that indeed need it.
- This to keep handling the authorization layer from the routers.