### PR TITLE
Fix user registration by switching to correct auth endpoint

### DIFF
--- a/frontends/web/src/new_front/pages/Login/Register.tsx
+++ b/frontends/web/src/new_front/pages/Login/Register.tsx
@@ -25,7 +25,7 @@ const Register = () => {
   };
 
   const onSubmit = async (values: any) => {
-    await post("user/create_user", {
+    await post("auth/create_user", {
       email: values.email,
       password: values.password,
       username: values.username,


### PR DESCRIPTION
### Problem
The registration form in `Register.tsx` currently sends a `POST` request to `user/create_user`, which requires authentication and therefore fails with a 401 error for unauthenticated users.

This breaks new user registration.

### Fix
The backend already exposes a public `POST /auth/create_user` route specifically for this purpose. This PR updates the frontend code to use the correct endpoint.

### Result
After this change, registration works as expected for unauthenticated users, returning a success message or the appropriate error (e.g., email already exists).

---

Let me know if this should be handled differently or if additional validation is needed!