### PR TITLE
Fix - Backend call from API

### DIFF
--- a/api/controllers/auth.py
+++ b/api/controllers/auth.py
@@ -27,7 +27,7 @@ def authenticate():
     user_name = data["email"].split("@")[0]
     if any(provider in email_provider for provider in ["prolific", "amazonturk"]):
         requests.post(
-            "https://backend.dynabench.org/user/create_user",
+            "https://backend.dynabench.org/user_public/create_user",
             json={
                 "email": data["email"],
                 "password": data["password"],


### PR DESCRIPTION
## Context

- Endpoint to create and authenticate user directly into challenge stopped working.

## Changes Made

1. Implement the new endpoint to create users on the API.
- This would allow the endpoint to work properly once more.