### PR TITLE
Fixture - Order in History

### DIFF
--- a/frontends/web/src/new_front/components/CreateSamples/CreateSamples/AnnotationInterfaces/Contexts/Chatbot.tsx
+++ b/frontends/web/src/new_front/components/CreateSamples/CreateSamples/AnnotationInterfaces/Contexts/Chatbot.tsx
@@ -97,10 +97,11 @@ const Chatbot: FC<ChatbotProps> = ({
         }
         const generationId = generateId();
         setNewResponses(
-          generatedTexts.map((text: any) => ({
+          generatedTexts.map((text: any, index: number) => ({
             ...text,
             score: 50,
             generationId: generationId,
+            originalPosition: index + 1,
           })) as any
         );
         setCurrentGenerationId(generationId);
@@ -380,7 +381,11 @@ const Chatbot: FC<ChatbotProps> = ({
                                     (text: any, i: number) => (
                                       <div
                                         key={`index${i}id${text.id}`}
-                                        className="w-full"
+                                        className={`w-full order-${
+                                          text.originalPosition <= 12
+                                            ? text.originalPosition
+                                            : "last"
+                                        }`}
                                       >
                                         <div className="relative p-3 bg-gray-100 border border-gray-200 rounded-lg">
                                           <textarea
@@ -393,7 +398,14 @@ const Chatbot: FC<ChatbotProps> = ({
                                       </div>
                                     )
                                   )}
-                                <div className="w-full">
+                                <div
+                                  className={`w-full order-${
+                                    chatHistory.bot[index].originalPosition <=
+                                    12
+                                      ? chatHistory.bot[index].originalPosition
+                                      : "last"
+                                  }`}
+                                >
                                   <div className="relative p-1 bg-green-50 border-2 border-green-300 rounded-lg shadow-md">
                                     <div className="absolute top-2 left-2 bg-green-600 text-white text-xs px-2 py-1 rounded font-semibold">
                                       ✓ Selected

--- a/frontends/web/src/new_front/components/CreateSamples/CreateSamples/AnnotationInterfaces/Contexts/EvaluateTextsGenerative.tsx
+++ b/frontends/web/src/new_front/components/CreateSamples/CreateSamples/AnnotationInterfaces/Contexts/EvaluateTextsGenerative.tsx
@@ -129,10 +129,11 @@ const EvaluateTextsGenerative: FC<
           window.location.reload();
         }
         setTexts(
-          generatedTexts.map((text: any) => ({
+          generatedTexts.map((text: any, index: number) => ({
             ...text,
             score: 50,
             generationId: generationId,
+            originalPosition: index + 1,
           }))
         );
         updateModelInputs({
@@ -228,7 +229,13 @@ const EvaluateTextsGenerative: FC<
     const chosenText = option
       ? texts.find((text) => text.id === parseInt(option))
       : reducedText;
-    const secondaryTexts = texts.filter((text) => text.id !== chosenText?.id);
+    const secondaryTexts = texts
+      .filter((text) => text.id !== chosenText?.id)
+      .map((text) => ({
+        id: text.id,
+        text: text.text,
+        originalPosition: text.originalPosition,
+      }));
 
     setChatHistory({
       ...chatHistory,
@@ -237,6 +244,7 @@ const EvaluateTextsGenerative: FC<
         {
           id: "1",
           text: chosenText.text,
+          originalPosition: chosenText.originalPosition,
           other_texts: secondaryTexts,
         },
       ],

--- a/frontends/web/src/new_front/components/Inputs/EvaluateText.tsx
+++ b/frontends/web/src/new_front/components/Inputs/EvaluateText.tsx
@@ -102,6 +102,7 @@ const EvaluateText: FC<EvaluateTextProps> = ({
               text={"Top Answer 👍👍"}
               className="border-0 font-weight-bold light-gray-bg task-action-btn"
               active={score === 100}
+              disabled={disabled}
             />
           </div>
         )}

--- a/frontends/web/src/new_front/types/createSamples/createSamples/utils.ts
+++ b/frontends/web/src/new_front/types/createSamples/createSamples/utils.ts
@@ -21,6 +21,7 @@ export type ChatbotProps = {
   setIsGenerativeContext: (isGenerativeContext: boolean) => void;
   modelInputs?: any;
   chooseWhenTie?: boolean;
+  showChosenHistory?: boolean;
 };
 
 export type SimpleChatbotProps = {


### PR DESCRIPTION
## Context

- The History of all the answers given by the models were shown but not on the same order they had been displayed before when the user rated them.

## Changes Made

1. Include the order number to each text in which they come from the model.
- This would allow us to render them the same as when they were shown the first time.
<img width="1282" height="714" alt="image" src="https://github.com/user-attachments/assets/9e87ad62-14f5-4f81-9908-6a4e2804031c" />
<img width="1204" height="307" alt="image" src="https://github.com/user-attachments/assets/30d12a44-2fac-45a6-a3d8-0a0f50d88bbe" />
<img width="1269" height="657" alt="image" src="https://github.com/user-attachments/assets/f1334148-36b2-48f5-984b-26a0514a4403" />
